### PR TITLE
Fix cibuildwheel setup for pybind11 extension

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.2
@@ -36,9 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
       - name: Build sdist
-        run: pipx run build --sdist
+        run: python -m build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools>=61", "pybind11>=2.10.0"]
+requires = ["setuptools>=61", "wheel", "pybind11>=2.10.0", "numpy>=1.20.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -63,9 +63,7 @@ test-requires = "pytest"
 test-command = "pytest {project}/tests -v"
 # Skip PyPy and musllinux for now
 skip = "pp* *-musllinux*"
-
-[tool.cibuildwheel.linux]
-before-all = "yum install -y gcc-c++ || apt-get update && apt-get install -y g++"
+before-build = "pip install numpy pybind11"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, Extension
 import pybind11
+import numpy
 
 ext_modules = [
     Extension(
         "cvqp.libs.proj_sum_largest_cpp",
         ["cvqp/libs/bindings.cpp", "cvqp/libs/sum_largest_proj.cpp"],
-        include_dirs=[pybind11.get_include()],
+        include_dirs=[pybind11.get_include(), numpy.get_include()],
         extra_compile_args=["-std=c++11", "-O3"],
         language="c++",
     ),


### PR DESCRIPTION
## Summary
- ensure numpy headers available for C++ build
- configure cibuildwheel to install build deps and target all platforms
- build wheels and sdist in GitHub Actions

## Testing
- `python -m pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_b_68c7bde146d4832892b464d4911854e4